### PR TITLE
Added custom reponse showing the errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/br/com/juwer/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/br/com/juwer/algafoodapi/api/exceptionhandler/ApiExceptionHandler.java
@@ -1,13 +1,19 @@
 package br.com.juwer.algafoodapi.api.exceptionhandler;
 
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import br.com.juwer.algafoodapi.domain.exception.EntidadeEmUsoException;
 import br.com.juwer.algafoodapi.domain.exception.EntidadeNaoEncontradaException;
@@ -34,8 +40,14 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
   public ResponseEntity<?> handleNegocioException(
         NegocioException ex, WebRequest request) {
     
+    String detail = ex.getMessage();
+    HttpStatus status = HttpStatus.BAD_REQUEST;
+    ProblemType problemType = ProblemType.ERRO_NEGOCIO;
+    
+    Problem problem = createProblemBuilder(status, problemType, detail).build();
+    
     return handleExceptionInternal(
-        ex, ex.getMessage(), new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+        ex, problem, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
   }
 
   @ExceptionHandler(EntidadeEmUsoException.class)
@@ -49,6 +61,24 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
     
     return handleExceptionInternal(
           ex, problem, new HttpHeaders(), HttpStatus.CONFLICT, request);
+  }
+  
+  @Override
+  protected ResponseEntity<Object> handleHttpMessageNotReadable(
+      HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+    
+    Throwable rootCause = ExceptionUtils.getRootCause(ex);
+    
+    if(rootCause instanceof InvalidFormatException) {
+      return handleInvalidFormatException((InvalidFormatException) rootCause, headers, status, request);
+    }
+    
+    String detail = "O corpo da requisição está inválido. Verifique erro de sintaxe";
+    ProblemType problemType = ProblemType.MESAGEM_INCOMPREENSIVEL;
+    
+    Problem problem = createProblemBuilder(status, problemType, detail).build();
+    
+    return handleExceptionInternal(ex, problem, headers, status, request);
   }
   
   @Override
@@ -74,5 +104,22 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
             .type(problem.getUri())
             .title(problem.getTitle())
             .detail(detail);
+  }
+  
+  private ResponseEntity<Object> handleInvalidFormatException(InvalidFormatException ex, HttpHeaders headers,
+      HttpStatus status, WebRequest request) {
+    
+    String path = ex.getPath().stream()
+        .map(ref -> ref.getFieldName())
+        .collect(Collectors.joining("."));
+    
+    String detail = String.format("A propriedade '%s' recebeu o valor '%s', "
+        + "que é de um tipo inválido. Corrija e informe o valor compátivel com o tipo '%s'", 
+        path, ex.getValue(), ex.getTargetType().getSimpleName());
+    
+    ProblemType problemType = ProblemType.MESAGEM_INCOMPREENSIVEL;
+    Problem problem = createProblemBuilder(status, problemType, detail).build();
+    
+    return handleExceptionInternal(ex, problem, headers, status, request);
   }
 }

--- a/src/main/java/br/com/juwer/algafoodapi/api/exceptionhandler/ProblemType.java
+++ b/src/main/java/br/com/juwer/algafoodapi/api/exceptionhandler/ProblemType.java
@@ -5,9 +5,10 @@ import lombok.Getter;
 @Getter
 public enum ProblemType {
 
+  MESAGEM_INCOMPREENSIVEL("/mensagem-incompreensivel", "Mensagem Incompreensível"),
   ENTIDADE_NAO_ECONTRADA("/entidade-nao-econtrada", "Entidade não encontrada"),
-  ENTIDADE_EM_USO("/entidade-em-uso", "Entidade em uso");
-  
+  ENTIDADE_EM_USO("/entidade-em-uso", "Entidade em uso"),
+  ERRO_NEGOCIO("/erro-negocio", "Violação de regra de negócio");         
   
   private String uri;
   private String title;


### PR DESCRIPTION
Created two new methods in class ApiExceptionHandler to handle with HttpMessageNotReadable and InvalidFormatException,
HttpMessageNotReadable: is handled in case of request's payload contains a missed comma or something like that.
InvalidFormatException:  is handled in case of request's payload have a field String insted of a long or vice versa.