### PR TITLE
Adjusted field in RestauranteDTO

### DIFF
--- a/src/main/java/br/com/juwer/algafoodapi/api/model/dto/RestauranteDTO.java
+++ b/src/main/java/br/com/juwer/algafoodapi/api/model/dto/RestauranteDTO.java
@@ -12,5 +12,5 @@ public class RestauranteDTO {
     private Long id;
     private String nome;
     private BigDecimal taxaFrete;
-    private CozinhaDTO cozinhaDTO;
+    private CozinhaDTO cozinha;
 }


### PR DESCRIPTION
Renamed field cozinhaDTO to cozinha at the class RestauranteDTO.
ModelMapper was unable to convert because the fields were with different names.