### PR TITLE
fix: Fixed duplicated selects when GET cidades/id

### DIFF
--- a/src/main/java/br/com/juwer/algafoodapi/domain/repository/CidadeRepository.java
+++ b/src/main/java/br/com/juwer/algafoodapi/domain/repository/CidadeRepository.java
@@ -14,4 +14,7 @@ public interface CidadeRepository extends JpaRepository<Cidade, Long> {
 
     @Query(value = "from Cidade c join fetch c.estado")
     List<Cidade> findAllCidades();
+
+    @Query(value = "from Cidade c join fetch c.estado where c.id = :cidadeId")
+    Optional<Cidade> findById(Long cidadeId);
 }


### PR DESCRIPTION
Overrided method findById:
Default implementation was duplicating the selects:
Created custom JPQL query with an join to avoid duplications;